### PR TITLE
Rough stab at making the default template settings-driven

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -1,6 +1,6 @@
 import { now } from 'moment';
 import { Vault, normalizePath } from 'obsidian';
-import { DAY_PLANNER_DEFAULT_CONTENT, DAY_PLANNER_FILENAME } from './constants';
+import { DAY_PLANNER_FILENAME } from './constants';
 import MomentDateRegex from './moment-date-regex';
 import { DayPlannerSettings, DayPlannerMode, NoteForDateQuery } from './settings';
 
@@ -61,7 +61,7 @@ export default class DayPlannerFile {
         try {
             const normalizedFileName = normalizePath(fileName);
             if (!await this.vault.adapter.exists(normalizedFileName, false)) {
-                await this.vault.create(normalizedFileName, DAY_PLANNER_DEFAULT_CONTENT);
+                await this.vault.create(normalizedFileName, DayPlannerSettings.defaultContent);
             }
         } catch (error) {
             console.log(error)

--- a/src/planner-md.ts
+++ b/src/planner-md.ts
@@ -1,5 +1,5 @@
 import type { MarkdownView, Workspace } from 'obsidian';
-import { DAY_PLANNER_DEFAULT_CONTENT, MERMAID_REGEX } from './constants';
+import { MERMAID_REGEX } from './constants';
 import type DayPlannerFile from './file';
 import PlannerMermaid from './mermaid';
 import type Parser from './parser';
@@ -32,7 +32,7 @@ export default class PlannerMarkdown {
         const fileContents = await (await this.file.getFileContents(filePath)).split('\n');
         const view = this.workspace.activeLeaf.view as MarkdownView;
         const currentLine = view.sourceMode.cmEditor.getCursor().line;
-        const insertResult = [...fileContents.slice(0, currentLine), ...DAY_PLANNER_DEFAULT_CONTENT.split('\n'), ...fileContents.slice(currentLine)];
+        const insertResult = [...fileContents.slice(0, currentLine), ...DayPlannerSettings.defaultContent.split('\n'), ...fileContents.slice(currentLine)];
         this.file.updateFile(filePath, insertResult.join('\n'));
     }
 

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -100,6 +100,17 @@ import type DayPlanner from './main';
                 this.plugin.settings.timelineZoomLevel = value;
                 this.plugin.saveData(this.plugin.settings);
               }));
+
+      new Setting(containerEl)
+        .setName('Template')
+        .setDesc('This template will be used when creating a new Dayplanner note.')
+        .addTextArea(text => text
+          .setValue(this.plugin.settings.defaultContent)
+          .onChange((value:string) => {
+            this.plugin.settings.defaultContent = value;
+            this.plugin.saveData(this.plugin.settings);
+          })
+        );
     }
 
     private modeDescriptionContent(): DocumentFragment {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -8,6 +8,9 @@ export class DayPlannerSettings {
   nowAndNextInStatusBar: boolean = false;
   showTaskNotification: boolean = false
   timelineZoomLevel: number = 4;
+  defaultContent: string = 
+    `## Day Planner
+    - [ ] `;
 }
 
 export class NoteForDate {


### PR DESCRIPTION
This is a quick stab at converting the templating to be dynamic. I was not able to get the project to build locally, so this is completely untested, but the changes appear to be quite simple. Along with other users in the issue thread at https://github.com/lynchjames/obsidian-day-planner/issues/56 , being able to customize my default Day Planner would be a fantastic QOL improvement.