### PR TITLE
add break and end css classes to the timeline.

### DIFF
--- a/src/timeline.svelte
+++ b/src/timeline.svelte
@@ -76,6 +76,14 @@
       return item.isPast ? 'past' : '';
     }
 
+    function breakClass(item: PlanItem) {
+      return item.text === 'BREAK' ? 'break' : '';
+    }
+
+    function endClass(item: PlanItem) {
+      return item.text === 'END' ? 'end' : '';
+    }
+
 </script>
 
 <style>
@@ -361,7 +369,7 @@ color:#fff;
         
       <div class="events">
         {#each summary.items as item, i}
-            <div class="event_item event_item_color{i%10+1} {shortClass(item)} {pastClass(item)}" style="height: {item.durationMins*timelineZoomLevel}px;" data-title="{item.rawTime}">
+            <div class="event_item event_item_color{i%10+1} {shortClass(item)} {pastClass(item)} {breakClass(item)} {endClass(item)}" style="height: {item.durationMins*timelineZoomLevel}px;" data-title="{item.rawTime}">
               <div class="event_item_contents">
                 <div class="ei_Dot {item === summary.current ? 'dot_active' : ''}"></div>
                 <div class="ei_Title">{item.rawTime}</div>


### PR DESCRIPTION
Add break and end css classes to the timeline so users can customize them e.g removing color from them.

Important: I haven't included tests and currently I don't have intentions on adding them, I just modified the code to make it work based on my personal needs and using manual installation until this feature is available on the plugin.