### PR TITLE
Sort tasks by time

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -34,7 +34,7 @@ export default class Parser {
     }
 
     private transform(regexMatches: {index: number, value: RegExpExecArray}[]): PlanItem[]{
-        const results = regexMatches.map((match) => {
+        let results = regexMatches.map((match) => {
             try {
                 const value = match.value;
                 const isCompleted = this.matchValue(value.groups.completion, 'x');
@@ -58,6 +58,9 @@ export default class Parser {
             } catch (error) {
                 console.log(error);
             }
+        });
+        results = results.sort(function(planItemA, planItemB) {
+            return planItemA.time.valueOf() - planItemB.time.valueOf();
         });
         return results;
     }

--- a/tests/fixtures/unordered_test.md
+++ b/tests/fixtures/unordered_test.md
@@ -1,0 +1,13 @@
+## Day Planner
+
+- [x] 8:00 morning stuff
+- [x] 9:00 breakfast
+- [x] 11:00 ☕️ Coffee Break
+- [ ] 11:10 reading
+- [ ] 12:00 writing
+- [ ] 13:00 ☕️ COFFEE BREAK
+- [ ] 14:00 🛑 Finish
+
+### Meetings
+- [x] 10:00 meeting
+- [ ] 13:10 meeting

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -5,6 +5,7 @@ import { expect } from 'chai';
 
 import Parser from '../src/parser';
 import { DayPlannerSettings } from '../src/settings';
+import type {PlanItem} from "../src/plan-data";
 
 describe('parser', () => {
   it('should return parsed items', async () => {
@@ -56,5 +57,28 @@ describe('parser', () => {
     expect(ninthItem.isEnd).to.be.true;
     expect(ninthItem.rawTime).to.eql('14:00');
     expect(ninthItem.text).to.eql('🛑 FINISH');
+  });
+  it('should return parsed items sorted by time', async () => {
+    const orderedFileContents = fs.readFileSync(path.join(__dirname, 'fixtures/test.md')).toString().split('\n');
+    const unOrderedFileContents = fs.readFileSync(path.join(__dirname, 'fixtures/unordered_test.md')).toString().split('\n');
+
+    const settings = new DayPlannerSettings();
+    settings.breakLabel = '☕️ COFFEE BREAK';
+    settings.endLabel = '🛑 FINISH';
+
+    const parser = new Parser(settings);
+    let orderedResults = await parser.parseMarkdown(orderedFileContents);
+    let unOrderedResults = await parser.parseMarkdown(unOrderedFileContents);
+
+    // Remove fields that won't match
+    function removeKeys (item: PlanItem) {
+      delete item['matchIndex'];
+      delete item['time'];
+      return item;
+    }
+
+    orderedResults.items = orderedResults.items.map(removeKeys);
+    unOrderedResults.items = unOrderedResults.items.map(removeKeys);
+    expect(orderedResults).to.eql(unOrderedResults);
   });
 });


### PR DESCRIPTION
https://github.com/lynchjames/obsidian-day-planner/issues/106

After parsing, orders items by time. Added unit test and tested on my local Obsidian installation (macOS Catalina 10.15.7) 