### PR TITLE
Sort PlanSummaryData items by time

### DIFF
--- a/src/plan-data.ts
+++ b/src/plan-data.ts
@@ -13,7 +13,7 @@ export class PlanSummaryData {
     constructor(items: PlanItem[]){
         this.empty = items.length < 1;
         this.invalid = false;
-        this.items = items;
+        this.items = items.sort((a, b) => (a.time < b.time ? -1 : 1));
         this.past = [];
     }
 


### PR DESCRIPTION
This commit makes sure that all PanItems are sorted by timne in the
summary data. This allows for having separate sections with time slots
throughout the note and still have them presented organzied in the
timeline.

![image](https://user-images.githubusercontent.com/13816/167580558-80ec430e-d52b-4ad5-8d38-445c54ee8ffb.png)


Fixes #106