### PR TITLE
fix: allow capital 'AM' and 'PM' in 12 hour format

### DIFF
--- a/src/regexp.ts
+++ b/src/regexp.ts
@@ -11,7 +11,7 @@ const hours = `\\d{1,2}`;
 const minutes = `\\d{2}`;
 const hourMinuteSeparator = `[:. ]`;
 
-const time = `(${hours})(?:${hourMinuteSeparator}?(${minutes}))?\\s*([ap]m)?`;
+const time = `(${hours})(?:${hourMinuteSeparator}?(${minutes}))?\\s*([apAP][mM])?`;
 
 export const timeRegExp = new RegExp(time);
 export const timestampRegExp = new RegExp(

--- a/src/timestamp/timestamp.test.ts
+++ b/src/timestamp/timestamp.test.ts
@@ -14,6 +14,9 @@ it.each([
   ["3pm", { hours: 15, minutes: 0 }],
   ["11 pm ", { hours: 23, minutes: 0 }],
   ["0301pm", { hours: 15, minutes: 1 }],
+  ["3PM", { hours: 15, minutes: 0 }],
+  ["11 PM ", { hours: 23, minutes: 0 }],
+  ["0301PM", { hours: 15, minutes: 1 }],
 ])("Parses timestamp %s", (asText, object) => {
   expect(parseTimestamp(asText, moment()).toObject()).toMatchObject(object);
 });


### PR DESCRIPTION
previous behavior only allowed 'am' and 'pm'.

Note for @ivan-lednev: the current linting process that husky initiates on commit is not friendly to windows machines. If you have `autocrlf = true`, git converts line endings from LF to CRLF when checking out files, and then from CRLF back to LF on commit. The current linting process seems to happen before that conversion back to LF, and Prettier 'fixes' all of the files and changes them to LF, which are tracked as changes in the commit.

I had to switch to `autocrlf = input` before cloning to commit properly, which does not do any LF->CRLF conversions at all.

PS: Thank you for picking this plugin back up! 
EDIT: editing this pr message also appears to cause commitlint to fail the test