### PR TITLE
fix: don't checkout crlf ever on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+﻿* text eol=lf


### PR DESCRIPTION
From my testing just now, this appears to fix the issue. It essentially tells git to ignore `autocrlf` when checking this repo out, and _always_ use lf endings. Switching back to `autocrlf=true` and checking my own fork out had no issues with this set.


`* text eol=lf` reads as 'for all file endings, if git can tell this is a text-type file, use LF line endings'.