### PR TITLE
fix: tasks on timeline not adjusting to zoom

### DIFF
--- a/src/ui/components/rendered-markdown.svelte
+++ b/src/ui/components/rendered-markdown.svelte
@@ -3,10 +3,7 @@
   import { onDestroy } from "svelte";
 
   import { appStore } from "../../store/app-store";
-  import type { IContrastColors } from "../../util/color";
-
   export let text: string;
-  export let properContrastColors: IContrastColors;
 
   let markdownLifecycleManager = new Component();
   let el: HTMLDivElement;
@@ -30,19 +27,12 @@
   }
 </script>
 
-<div bind:this={el}
-     style="
-
-     --text-normal: {properContrastColors.normal};
-     --text-muted: {properContrastColors.muted};
-     --text-faint: {properContrastColors.faint}
-    "
-     class="rendered-markdown"></div>
+<div bind:this={el} class="rendered-markdown"></div>
 
 <style>
   .rendered-markdown {
     --checkbox-size: var(--font-ui-small);
-
+    color: var(--text-normal);
     flex: 1 0 0;
   }
 

--- a/src/ui/components/task.svelte
+++ b/src/ui/components/task.svelte
@@ -44,7 +44,7 @@
     : "var(--background-primary)";
 
   let properContrastColors: IContrastColors;
-  $: properContrastColors = $settings.timelineColored && planItem.startTime
+  $: properContrastColors = backgroundColor.startsWith("#") && planItem.startTime
     ? getTextColorWithEnoughContrast(backgroundColor)
     : {
       normal: "var(--text-normal)",

--- a/src/ui/components/task.svelte
+++ b/src/ui/components/task.svelte
@@ -44,7 +44,7 @@
     : "var(--background-primary)";
 
   let properContrastColors: IContrastColors;
-  $: properContrastColors = backgroundColor.startsWith("#") && planItem.startTime
+  $: properContrastColors = $settings.timelineColored && planItem.startTime
     ? getTextColorWithEnoughContrast(backgroundColor)
     : {
       normal: "var(--text-normal)",
@@ -83,11 +83,6 @@
 
 <!--  overwrite global theme colors with contrasting text colors, when using colored theme-->
 <div
-  style="
-
-  --text-normal: {properContrastColors.normal};
-  --text-muted: {properContrastColors.muted};
-  --text-faint: {properContrastColors.faint}"
   style:height="{height}px"
   style:transform="translateY({offset}px)"
   style:width="{planItem.placing.widthPercent || 100}%"
@@ -116,7 +111,10 @@
       editor.setCursor({ line: planItem.location.line, ch: 0 });
     }}
   >
-    <RenderedMarkdown {properContrastColors} text={planItem.text}/>
+    <RenderedMarkdown text={planItem.text} 
+                      --text-normal="{properContrastColors.normal}"
+                      --text-muted="{properContrastColors.muted}"
+                      --text-faint="{properContrastColors.faint}"/>
     <div
       style:cursor={$cursor}
       class="grip"
@@ -164,7 +162,6 @@
     padding: 4px 6px 6px;
 
     font-size: var(--font-ui-small);
-    color: var(--text-normal);
     text-align: left;
     overflow-wrap: anywhere;
     white-space: normal;


### PR DESCRIPTION
#243 

There are issues in svelte with cascading dependencies in reactive declarations, from what I understand.
Since `background color` relies on `$store.timelineColored`, having `textColor` rely on both seemed to cause issues. Removing the direct dependency of the store works, anyway.

Fix gif: 
![zoom](https://github.com/ivan-lednev/obsidian-day-planner/assets/6687530/b15e6a1c-d791-452e-9247-375202793764)
