### PR TITLE
fix: fix rectangle is too long and goes over day

### DIFF
--- a/src/ui/components/task.svelte
+++ b/src/ui/components/task.svelte
@@ -17,7 +17,7 @@
 </script>
 
 <div
-  style:height="{$height}px"
+  style:height="{($height + $offset >= 1080) ? 1080-$offset : $height}px"
   style:transform="translateY({$offset}px)"
   style:width="{planItem.placing.widthPercent || 100}%"
   style:left="{planItem.placing.xOffsetPercent || 0}%"


### PR DESCRIPTION
fix #254. If task with offset is higher then 1080 (max possible height) then the height is set to the 1080-offset. To get exactly 1080.