### PR TITLE
feat: decouple loading of planned items

### DIFF
--- a/src/planned-items/day.ts
+++ b/src/planned-items/day.ts
@@ -1,0 +1,37 @@
+import { Moment } from "moment/moment";
+
+export default class Day {
+  private static instances = new Map<string, Day>();
+
+  private constructor(
+    public readonly year: number,
+    public readonly month: number,
+    public readonly day: number,
+  ) {}
+
+  public asIso(): string {
+    return `${this.year.toString().padStart(4, "0")}-${this.month
+      .toString()
+      .padStart(2, "0")}-${this.day.toString().padStart(2, "0")}`;
+  }
+
+  public equals(other: Day): boolean {
+    return (
+      this.year === other.year &&
+      this.month === other.month &&
+      this.day === other.day
+    );
+  }
+
+  public static fromMoment(moment: Moment): Day {
+    const key = moment.format("YYYY-MM-DD");
+    if (!this.instances.has(key)) {
+      this.instances.set(
+        key,
+        new Day(moment.year(), moment.month() + 1, moment.date()),
+      );
+    }
+
+    return this.instances.get(key);
+  }
+}

--- a/src/planned-items/loader/composite-loader.ts
+++ b/src/planned-items/loader/composite-loader.ts
@@ -1,0 +1,23 @@
+import Day from "../day";
+import { PlannedItemLoader } from "../planned-items";
+
+export default class CompositeLoader<T> implements PlannedItemLoader<T> {
+  constructor(private taskLoaders: Array<PlannedItemLoader<T>>) {}
+
+  public async forDays(days: Set<Day>): Promise<Map<Day, Array<T>>> {
+    const result = new Map();
+
+    for (const day of days) {
+      result.set(day, []);
+    }
+
+    for (const loader of this.taskLoaders) {
+      const loaderResult = await loader.forDays(days);
+      loaderResult.forEach((value, key) =>
+        result.set(key, result.get(key).concat(value)),
+      );
+    }
+
+    return result;
+  }
+}

--- a/src/planned-items/loader/daily-notes-item-loader.ts
+++ b/src/planned-items/loader/daily-notes-item-loader.ts
@@ -7,7 +7,10 @@ import { PlannedItem, PlannedItemLoader } from "../planned-items";
 export default class DailyNotesItemLoader
   implements PlannedItemLoader<PlannedItem>
 {
-  constructor(private dataview: DataviewApi) {}
+  constructor(
+    private dataview: DataviewApi,
+    private heading: string,
+  ) {}
 
   public async forDays(days: Set<Day>): Promise<Map<Day, Array<PlannedItem>>> {
     const allDailyNotes = getAllDailyNotes();
@@ -27,10 +30,34 @@ export default class DailyNotesItemLoader
 
       result.set(
         day,
-        tasks.filter((item) => !item.task || (item.task && !item.scheduled)),
+        tasks.filter((item) => this.isValidItem(item)),
       );
     }
 
     return result;
+  }
+
+  public setHeading(heading: string): void {
+    this.heading = heading;
+  }
+
+  private isValidItem(item: PlannedItem): boolean {
+    return (
+      this.inCorrectSection(item) &&
+      this.istopLevelItem(item) &&
+      this.islistItemOrUnscheduledTask(item)
+    );
+  }
+
+  private inCorrectSection(item: PlannedItem): boolean {
+    return item.section.subpath === this.heading;
+  }
+
+  private istopLevelItem(item: PlannedItem): boolean {
+    return !item.parent;
+  }
+
+  private islistItemOrUnscheduledTask(item: PlannedItem): boolean {
+    return !item.task || (item.task && !item.scheduled);
   }
 }

--- a/src/planned-items/loader/daily-notes-item-loader.ts
+++ b/src/planned-items/loader/daily-notes-item-loader.ts
@@ -1,0 +1,36 @@
+import { getAllDailyNotes, getDailyNote } from "obsidian-daily-notes-interface";
+import { DataviewApi } from "obsidian-dataview";
+
+import Day from "../day";
+import { PlannedItem, PlannedItemLoader } from "../planned-items";
+
+export default class DailyNotesItemLoader
+  implements PlannedItemLoader<PlannedItem>
+{
+  constructor(private dataview: DataviewApi) {}
+
+  public async forDays(days: Set<Day>): Promise<Map<Day, Array<PlannedItem>>> {
+    const allDailyNotes = getAllDailyNotes();
+    const result = new Map();
+
+    for (const day of days) {
+      const dailyNote = getDailyNote(window.moment(day.asIso()), allDailyNotes);
+      if (dailyNote === null) {
+        result.set(day, []);
+        continue;
+      }
+
+      const note = this.dataview.page(dailyNote.basename);
+
+      const tasks: Array<PlannedItem> =
+        typeof note === "undefined" ? [] : note.file.lists.values;
+
+      result.set(
+        day,
+        tasks.filter((item) => !item.task || (item.task && !item.scheduled)),
+      );
+    }
+
+    return result;
+  }
+}

--- a/src/planned-items/loader/null-loader.ts
+++ b/src/planned-items/loader/null-loader.ts
@@ -1,0 +1,8 @@
+import Day from "../day";
+import { PlannedItem, PlannedItemLoader } from "../planned-items";
+
+export default class NullLoader implements PlannedItemLoader<PlannedItem> {
+  public async forDays(days: Set<Day>): Promise<Map<Day, Array<PlannedItem>>> {
+    return new Map();
+  }
+}

--- a/src/planned-items/loader/profiling-wrapper.ts
+++ b/src/planned-items/loader/profiling-wrapper.ts
@@ -1,0 +1,29 @@
+import Day from "../day";
+import { PlannedItemLoader } from "../planned-items";
+
+export class ProfilingWrapper<T> implements PlannedItemLoader<T> {
+  constructor(private taskLoader: PlannedItemLoader<T>) {}
+
+  public async forDays(days: Set<Day>): Promise<Map<Day, Array<T>>> {
+    performance.mark("profiling-start");
+    const result = await this.taskLoader.forDays(days);
+    performance.mark("profiling-stop");
+
+    const measure = performance.measure(
+      "profiling-time",
+      "profiling-start",
+      "profiling-stop",
+    );
+
+    const args = Array.from(days.values())
+      .map((day) => day.asIso())
+      .join(", ");
+    console.debug(
+      `${
+        this.taskLoader.constructor.name
+      }.forDays(${args}): ${measure.duration.toFixed(2)} ms`,
+    );
+
+    return result;
+  }
+}

--- a/src/planned-items/loader/scheduled-tasks-loader.ts
+++ b/src/planned-items/loader/scheduled-tasks-loader.ts
@@ -3,14 +3,6 @@ import { DataviewApi } from "obsidian-dataview";
 import Day from "../day";
 import { PlannedItem, PlannedItemLoader } from "../planned-items";
 
-function isScheduledForThisDay(task: PlannedItem, day: Day) {
-  if (!task?.scheduled?.toMillis) {
-    return false;
-  }
-
-  return day.equals(Day.fromMoment(window.moment(task.scheduled.toMillis())));
-}
-
 export default class ScheduledTasksLoader
   implements PlannedItemLoader<PlannedItem>
 {
@@ -18,27 +10,41 @@ export default class ScheduledTasksLoader
 
   public async forDays(days: Set<Day>): Promise<Map<Day, Array<PlannedItem>>> {
     const result = new Map();
+    const tasks = await this.tasksScheduledFor(days);
 
+    for (const day of days) {
+      result.set(
+        day,
+        tasks.filter((task) => this.isScheduledFor(task, day)),
+      );
+    }
+
+    return result;
+  }
+
+  private async tasksScheduledFor(days: Set<Day>): Promise<Array<PlannedItem>> {
+    const queryResult = await this.dataview.query(this.taskQueryFor(days));
+    if ("error" in queryResult) {
+      console.error(`Error querying data: ${queryResult.error}`);
+      return [];
+    }
+
+    return queryResult.value.values as Array<PlannedItem>;
+  }
+
+  private taskQueryFor(days: Set<Day>): string {
     const conditions = Array.from(days.values())
       .map((d) => `scheduled = date(${d.asIso()})`)
       .join(" OR ");
 
-    const queryResult = await this.dataview.query(`TASK WHERE ${conditions}`);
-    if ("error" in queryResult) {
-      console.error(`Error querying data: ${queryResult.error}`);
-      return result;
+    return `TASK WHERE ${conditions}`;
+  }
+
+  private isScheduledFor(task: PlannedItem, day: Day): boolean {
+    if (!task?.scheduled?.toMillis) {
+      return false;
     }
 
-    const dataviewTasks = queryResult.value.values as Array<PlannedItem>;
-
-    for (const day of days) {
-      const tasks = dataviewTasks.filter((task) =>
-        isScheduledForThisDay(task, day),
-      );
-
-      result.set(day, tasks);
-    }
-
-    return result;
+    return day.equals(Day.fromMoment(window.moment(task.scheduled.toMillis())));
   }
 }

--- a/src/planned-items/loader/scheduled-tasks-loader.ts
+++ b/src/planned-items/loader/scheduled-tasks-loader.ts
@@ -1,0 +1,44 @@
+import { DataviewApi } from "obsidian-dataview";
+
+import Day from "../day";
+import { PlannedItem, PlannedItemLoader } from "../planned-items";
+
+function isScheduledForThisDay(task: PlannedItem, day: Day) {
+  if (!task?.scheduled?.toMillis) {
+    return false;
+  }
+
+  return day.equals(Day.fromMoment(window.moment(task.scheduled.toMillis())));
+}
+
+export default class ScheduledTasksLoader
+  implements PlannedItemLoader<PlannedItem>
+{
+  constructor(private dataview: DataviewApi) {}
+
+  public async forDays(days: Set<Day>): Promise<Map<Day, Array<PlannedItem>>> {
+    const result = new Map();
+
+    const conditions = Array.from(days.values())
+      .map((d) => `scheduled = date(${d.asIso()})`)
+      .join(" OR ");
+
+    const queryResult = await this.dataview.query(`TASK WHERE ${conditions}`);
+    if ("error" in queryResult) {
+      console.error(`Error querying data: ${queryResult.error}`);
+      return result;
+    }
+
+    const dataviewTasks = queryResult.value.values as Array<PlannedItem>;
+
+    for (const day of days) {
+      const tasks = dataviewTasks.filter((task) =>
+        isScheduledForThisDay(task, day),
+      );
+
+      result.set(day, tasks);
+    }
+
+    return result;
+  }
+}

--- a/src/planned-items/planned-items.spec.ts
+++ b/src/planned-items/planned-items.spec.ts
@@ -1,0 +1,136 @@
+import moment from "moment";
+import { get } from "svelte/store";
+
+import Day from "./day";
+import { PlannedItems, PlannedItemLoader } from "./planned-items";
+
+const sleep = (milliseconds: number) =>
+  new Promise((r) => setTimeout(r, milliseconds));
+
+class MockLoader implements PlannedItemLoader<string> {
+  public readonly calls: Array<Array<Day>> = [];
+  private readonly items = new Map<Day, Array<string>>();
+
+  public async forDays(days: Set<Day>): Promise<Map<Day, Array<string>>> {
+    this.calls.push(Array.from(days));
+
+    const result = new Map<Day, Array<string>>();
+
+    days.forEach((day) => result.set(day, this.items.get(day)));
+
+    return result;
+  }
+
+  public setItems(day: Day, tasks: Array<string>) {
+    this.items.set(day, tasks);
+  }
+}
+
+const loadingDelayInMs = 5;
+const longEnoughToTriggerLoading = loadingDelayInMs + 2;
+
+const day1 = Day.fromMoment(moment("2023-10-10"));
+const day2 = Day.fromMoment(moment("2023-11-11"));
+const day3 = Day.fromMoment(moment("2023-12-12"));
+
+let loader = new MockLoader();
+let subject: PlannedItems<string>;
+
+describe("Planned Items", () => {
+  beforeEach(() => {
+    loader = new MockLoader();
+    subject = new PlannedItems(loader, loadingDelayInMs);
+  });
+
+  it("should return the queried data", async () => {
+    loader.setItems(day1, ["task-1"]);
+    loader.setItems(day2, ["task-2", "task-3"]);
+    loader.setItems(day3, ["task-4"]);
+
+    subject.forDay(day1).subscribe(jest.fn());
+    subject.forDay(day2).subscribe(jest.fn());
+    subject.forDay(day3).subscribe(jest.fn());
+    await sleep(longEnoughToTriggerLoading);
+
+    expect(get(subject.forDay(day1))).toEqual(["task-1"]);
+    expect(get(subject.forDay(day2))).toEqual(["task-2", "task-3"]);
+    expect(get(subject.forDay(day3))).toEqual(["task-4"]);
+  });
+
+  it("should load subscribed days only", async () => {
+    subject.forDay(day1).subscribe(jest.fn);
+    await sleep(longEnoughToTriggerLoading);
+
+    expect(loader.calls).toEqual([[day1]]);
+  });
+
+  it("should load data in batches", async () => {
+    subject.forDay(day1).subscribe(jest.fn);
+    subject.forDay(day2).subscribe(jest.fn);
+    await sleep(longEnoughToTriggerLoading);
+    subject.forDay(day3).subscribe(jest.fn);
+    await sleep(longEnoughToTriggerLoading);
+
+    expect(loader.calls).toEqual([[day1, day2], [day3]]);
+  });
+
+  it("must not requery data if there was no refresh", async () => {
+    subject.forDay(day1).subscribe(jest.fn);
+    await sleep(longEnoughToTriggerLoading);
+    subject.forDay(day2).subscribe(jest.fn);
+    await sleep(longEnoughToTriggerLoading);
+    subject.forDay(day1).subscribe(jest.fn);
+    subject.forDay(day2).subscribe(jest.fn);
+    subject.forDay(day3).subscribe(jest.fn);
+    await sleep(longEnoughToTriggerLoading);
+
+    expect(loader.calls).toEqual([[day1], [day2], [day3]]);
+  });
+
+  it("should requery data after a refresh", async () => {
+    subject.forDay(day1).subscribe(jest.fn);
+    subject.forDay(day3).subscribe(jest.fn);
+    await sleep(longEnoughToTriggerLoading);
+    subject.refresh();
+    subject.forDay(day2).subscribe(jest.fn);
+    await sleep(longEnoughToTriggerLoading);
+
+    expect(loader.calls).toEqual([
+      [day1, day3],
+      [day1, day3, day2],
+    ]);
+  });
+
+  it("must not requery unsubscribed days after a refresh", async () => {
+    subject.forDay(day1).subscribe(jest.fn);
+    const unsubscribeDay2 = subject.forDay(day2).subscribe(jest.fn);
+    const unsubscribeDay3 = subject.forDay(day3).subscribe(jest.fn);
+    await sleep(longEnoughToTriggerLoading);
+    unsubscribeDay2();
+    unsubscribeDay3();
+    subject.refresh();
+    await sleep(longEnoughToTriggerLoading);
+
+    expect(loader.calls).toEqual([[day1, day2, day3], [day1]]);
+  });
+
+  it("should return the requeried data", async () => {
+    loader.setItems(day1, ["task-1"]);
+    loader.setItems(day2, ["task-2"]);
+    loader.setItems(day3, ["task-3"]);
+
+    subject.forDay(day1).subscribe(jest.fn());
+    subject.forDay(day2).subscribe(jest.fn());
+    subject.forDay(day3).subscribe(jest.fn());
+    await sleep(longEnoughToTriggerLoading);
+    loader.setItems(day1, ["new-task-1"]);
+    loader.setItems(day2, ["new-task-2"]);
+    loader.setItems(day3, ["new-task-3"]);
+    subject.refresh();
+    await sleep(longEnoughToTriggerLoading);
+
+    expect(get(subject.forDay(day1))).toEqual(["new-task-1"]);
+    expect(get(subject.forDay(day2))).toEqual(["new-task-2"]);
+    expect(get(subject.forDay(day3))).toEqual(["new-task-3"]);
+  });
+});

--- a/src/planned-items/planned-items.ts
+++ b/src/planned-items/planned-items.ts
@@ -1,0 +1,88 @@
+import { SListEntry, STask } from "obsidian-dataview";
+import { Readable, readable } from "svelte/store";
+
+import { debounceWithDelay } from "../util/debounce-with-delay";
+
+import Day from "./day";
+
+export type PlannedItem = STask | SListEntry;
+
+export interface PlannedItemLoader<T> {
+  forDays(days: Set<Day>): Promise<Map<Day, Array<T>>>;
+}
+
+export class PlannedItems<T> {
+  private queue = new Set<Day>();
+  private active = new Set<Day>();
+  private lastRefresh = new Date();
+  private cacheDate = new Map<Day, Date>();
+  private cacheUpdate = new Map<Day, (value: Array<T>) => void>();
+  private cache = new Map<Day, Readable<Array<T>>>();
+  private loadQueueDebounced: () => void;
+  public delayRefresh: () => void;
+
+  constructor(
+    private plannedItems: PlannedItemLoader<T>,
+    loadingDelayInMs: number,
+  ) {
+    [this.loadQueueDebounced, this.delayRefresh] = debounceWithDelay(
+      () => this.loadQueue(),
+      loadingDelayInMs,
+    );
+  }
+
+  public refresh(): void {
+    this.lastRefresh = new Date();
+
+    this.active.forEach((day) => this.addDayToLoadingQueue(day));
+  }
+
+  public forDay(day: Day): Readable<Array<T>> {
+    if (!this.cache.has(day)) {
+      this.cache.set(day, this.storeForDay(day));
+    }
+
+    return this.cache.get(day);
+  }
+
+  private addToQueueIfNotYetLoadedOrStale(day: Day): void {
+    const cacheDate = this.cacheDate.get(day);
+
+    if (cacheDate === undefined || cacheDate < this.lastRefresh) {
+      this.addDayToLoadingQueue(day);
+    }
+  }
+
+  private addDayToLoadingQueue(day: Day): void {
+    this.queue.add(day);
+
+    this.loadQueueDebounced();
+  }
+
+  private loadQueue(): void {
+    const queue = new Set(this.queue);
+    this.queue.clear();
+
+    queue.forEach((day) => this.cacheDate.set(day, new Date()));
+
+    this.plannedItems.forDays(queue).then((value) =>
+      value.forEach((tasks, key) => {
+        this.cacheUpdate.get(key)(tasks);
+      }),
+    );
+  }
+
+  private storeForDay(day: Day): Readable<Array<T>> {
+    return readable<Array<T>>([], (set) => {
+      this.active.add(day);
+
+      this.cacheUpdate.set(day, set);
+
+      this.addToQueueIfNotYetLoadedOrStale(day);
+
+      return () => {
+        this.active.delete(day);
+      };
+    });
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,11 @@
 import type { Moment } from "moment";
-import { MetadataCache, Pos } from "obsidian";
-import { Readable, Writable } from "svelte/store";
+import { Pos } from "obsidian";
+import { Writable } from "svelte/store";
 
 import type { getHorizontalPlacing } from "./overlap/horizontal-placing";
+import { PlannedItem, PlannedItems } from "./planned-items/planned-items";
 import type { ObsidianFacade } from "./service/obsidian-facade";
-import { useEditContext } from "./ui/hooks/use-edit/use-edit-context";
+import { PlanEditor } from "./service/plan-editor";
 import { getDiff, updateText } from "./util/tasks-utils";
 
 export interface TaskLocation {
@@ -72,13 +73,10 @@ export type GetTasksForDay = (day: Moment) => TasksForDay;
 
 export interface ObsidianContext {
   obsidianFacade: ObsidianFacade;
-  metadataCache: MetadataCache;
-  onUpdate: OnUpdateFn;
   initWeeklyView: () => Promise<void>;
-  getTasksForDay: Readable<GetTasksForDay>;
   refreshTasks: (source: string) => void;
   dataviewLoaded: Writable<boolean>;
   renderMarkdown: RenderMarkdown;
-  editContext: Readable<ReturnType<typeof useEditContext>>;
-  visibleTasks: Readable<Tasks>;
+  plannedItems: PlannedItems<PlannedItem>;
+  planEditor: PlanEditor;
 }

--- a/src/util/debounce-with-delay.ts
+++ b/src/util/debounce-with-delay.ts
@@ -15,9 +15,11 @@ export function debounceWithDelay(
   function debouncedFn(...args: unknown[]) {
     lastArgs = args;
 
-    if (!lastTimeout) {
-      set();
+    if (lastTimeout) {
+      clearTimeout(lastTimeout);
     }
+
+    set();
   }
 
   function delay() {


### PR DESCRIPTION
Hey @ivan-lednev 

here's my proposal for #282

I tried the suggestion from your last comment (https://github.com/ivan-lednev/obsidian-day-planner/issues/282#issuecomment-1804535147). It worked, but things got slower as I added more daily notes with more list items. The same happened with an increasing number of tasks. You already mentioned that you use lists for everything, so I wanted to come up with something that works long-term and with large vaults.

To me, the obvious solution was to load only what's necessary. I came up with this abstraction `PlannedItems` that takes care of that. You can request items for a given day and get a readable store in return that will eventually contain (meaning once loaded) the items. You can injects loaders into `PlannedItems` to do the actual data loading. There's one for scheduled tasks, and one for daily notes list items and unscheduled tasks, as well as some helpers. The actual data loading is debounced so items for the week planner are loaded in one fell swoop instead of seven queries. Once data is loaded, it will be returned without requerying. If there's a metadata change, stores that have a subscription will be updated. Unsubscribed stores with a stale cache will be updated once there's a new subscription.

I messed up a little with the integration, though. I hadn't updated my fork since I started working on this and when I fetched your changes I realized that you had refactored quite a bit. The way it is currently integrated is closer to how the codebase was a couple of weeks ago. My goal for the moment was to show you a working version so you can decide what to do with it.

I'm open to suggestions and happy to help.