### PR TITLE
fix: do not print undefined inside checkbox when list item is not a task

### DIFF
--- a/src/util/dataview.ts
+++ b/src/util/dataview.ts
@@ -51,7 +51,7 @@ export function toUnscheduledTask(sTask: STask, day: Moment) {
   return {
     durationMinutes: defaultDurationMinutes,
     // todo: bad abstraction
-    listTokens: `${sTask.symbol} [${sTask.status}] `,
+    listTokens: getListTokens(sTask),
     firstLineText: sTask.text,
     text: toString(sTask),
     location: {
@@ -81,7 +81,7 @@ export function toTask(sTask: STask, day: Moment): Task {
 
   return {
     startTime,
-    listTokens: `${sTask.symbol} [${sTask.status}] `,
+    listTokens: getListTokens(sTask),
     firstLineText,
     text,
     durationMinutes,
@@ -132,12 +132,17 @@ export function toMarkdown(sTask: STask) {
     .map((line, i) => {
       if (i === 0) {
         // TODO: remove duplication
-        return `${baseIndent}${sTask.symbol} [${sTask.status}] ${line}`;
+        return `${baseIndent}${getListTokens(sTask)}${line}`;
       }
 
       return `${baseIndent}${extraIndent}${line}`;
     })
     .join("\n");
+}
+
+function getListTokens(sTask: STask) {
+  const maybeCheckbox = sTask.status === undefined ? "" : `[${sTask.status}] `;
+  return `${sTask.symbol} ${maybeCheckbox}`;
 }
 
 export function replaceSTaskInFile(


### PR DESCRIPTION
Problem: When the list item does not have a checkbox (no `[x]` nor `[ ]`), moving it in the timeline causes `[undefined]` to be printed instead of the checkbox.

Solution: When rewriting the first line of the list item, only print the "checkbox" part when there used to be a checkbox before.

Fixes #368 

## Reproduction

1. Use the following Markdown document:
    
    ```md
    # Day planner
    
    - 09:00 - 09:30 Sleep
    ```

1. Move the task in the timeline (e.g. so it starts at 9:30)

### Before (on `main`)

There is an extra `[undefined]` entered where the checkbox field would normally be. This causes the list item to no longer be picked up by the plugin, and it disappears from the timeline.

```md
# Day planner

- [undefined] 09:30 - 10:00 Sleep
```

https://github.com/ivan-lednev/obsidian-day-planner/assets/889383/cd750d4d-f0af-4410-84c1-de582c3ac540


### After

```md
# Day planner

- 09:30 - 10:00 Sleep
```


https://github.com/ivan-lednev/obsidian-day-planner/assets/889383/31910067-4a2e-4853-b676-aaf7ddfcc48e

