### PR TITLE
feat: added text color override

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -9,6 +9,8 @@ export interface IcalConfig {
 
 export interface ColorOverride {
   text: string;
+  lightModeTextColor: string;
+  darkModeTextColor: string;
   color: string;
   darkModeColor: string;
 }

--- a/src/ui/components/rendered-markdown.svelte
+++ b/src/ui/components/rendered-markdown.svelte
@@ -5,14 +5,21 @@
   import { settings } from "../../global-store/settings";
   import type { ObsidianContext, UnscheduledTask } from "../../types";
   import { renderTaskMarkdown } from "../actions/render-task-markdown";
+  import { useTextColorOverride } from "../hooks/use-color-override";
 
   export let task: UnscheduledTask;
 
   // todo: use context inside action
   const { renderMarkdown } = getContext<ObsidianContext>(obsidianContext);
+
+  $: textColorOverride = useTextColorOverride(task);
+  // todo: hide in hook
+  $: textColor =
+      $textColorOverride || "var(--text-normal)";
 </script>
 
 <div
+  style:--overriden-text-color={textColor}
   class="rendered-markdown"
   use:renderTaskMarkdown={{ task, settings: $settings, renderMarkdown }}
 ></div>
@@ -36,7 +43,7 @@
     --checkbox-size: var(--font-ui-small);
 
     flex: 1 0 0;
-    color: var(--text-normal);
+    color: var(--overriden-text-color);
   }
 
   .rendered-markdown :global(p),
@@ -57,7 +64,7 @@
   }
 
   .rendered-markdown :global(li) {
-    color: var(--text-normal);
+    color: var(--overriden-text-color);
   }
 
   .rendered-markdown :global(li.task-list-item[data-task="x"]),

--- a/src/ui/hooks/use-color-override.ts
+++ b/src/ui/hooks/use-color-override.ts
@@ -18,3 +18,19 @@ export function useColorOverride(task: UnscheduledTask) {
     }
   });
 }
+
+export function useTextColorOverride(task: UnscheduledTask) {
+  const { isDarkMode } = getContext<ObsidianContext>(obsidianContext);
+
+  return derived([settings, isDarkMode], ([$settings, $isDarkMode]) => {
+    const colorOverride = $settings.colorOverrides.find((override) =>
+      task.firstLineText.includes(override.text),
+    );
+
+    if (colorOverride) {
+      return $isDarkMode
+        ? colorOverride?.darkModeTextColor
+        : colorOverride?.lightModeTextColor;
+    }
+  });
+}

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -419,6 +419,26 @@ export class DayPlannerSettingsTab extends PluginSettingTab {
     this.plugin.settings().colorOverrides.map((colorOverride, index) =>
       new Setting(containerEl)
         .setName(`Color ${index + 1}`)
+
+        // light mode text color
+        .addColorPicker((el) =>
+          // todo: replace with immer
+          el
+            .setValue(colorOverride.lightModeTextColor)
+            .onChange((value: string) => {
+              this.settingsStore.update((previous) => ({
+                ...previous,
+                colorOverrides: previous.colorOverrides.map(
+                  (editedOverride, editedIndex) =>
+                    editedIndex === index
+                      ? { ...editedOverride, lightModeTextColor: value }
+                      : editedOverride,
+                ),
+              }));
+            }),
+        )
+
+        // light mode background color
         .addColorPicker((el) =>
           // todo: replace with immer
           el.setValue(colorOverride.color).onChange((value: string) => {
@@ -433,6 +453,26 @@ export class DayPlannerSettingsTab extends PluginSettingTab {
             }));
           }),
         )
+
+        // dark mode text color
+        .addColorPicker((el) =>
+          // todo: replace with immer
+          el
+            .setValue(colorOverride.darkModeTextColor)
+            .onChange((value: string) => {
+              this.settingsStore.update((previous) => ({
+                ...previous,
+                colorOverrides: previous.colorOverrides.map(
+                  (editedOverride, editedIndex) =>
+                    editedIndex === index
+                      ? { ...editedOverride, darkModeTextColor: value }
+                      : editedOverride,
+                ),
+              }));
+            }),
+        )
+
+        // dark mode background color
         .addColorPicker((el) =>
           // todo: replace with immer
           el.setValue(colorOverride.darkModeColor).onChange((value: string) => {
@@ -486,6 +526,8 @@ export class DayPlannerSettingsTab extends PluginSettingTab {
           text: "#important",
           darkModeColor: "#6e3737",
           color: "#ffa1a1",
+          lightModeTextColor: "#000000",
+          darkModeTextColor: "#ffffff",
         };
 
         this.settingsStore.update((previous) => ({


### PR DESCRIPTION
This PR adds support for overriding light/dark mode timeblock text color (previously only the backgroundColor was customizable)

Closes #481

# Screenshots

### Settings

![image](https://github.com/ivan-lednev/obsidian-day-planner/assets/18697399/cf27ad0d-e5a8-420e-9c1c-b7a36d080d64)

Second and fourth color pickers are light mode and dark mode text colors respectively

### Light mode based on above settings

![image](https://github.com/ivan-lednev/obsidian-day-planner/assets/18697399/bd1d5328-72ee-473e-91b8-7c170efaab56)

### Dark mode based on above settings

![image](https://github.com/ivan-lednev/obsidian-day-planner/assets/18697399/c7d6fb59-ba70-4399-87d3-70dbd2db8e84)

# Other thoughts while working on this PR

- Override settings should possibly be redesigned since it's not obvious which color picker does what
- Looks like prettier was enabled but previous code wasn't run through it, it blocked copypasted code from the same file `settings-tab.ts`, check the diff
- Tags still don't look perfect on the attached screenshots but it may be a bit more difficult to override them (possibly add an option to hide tags completely since color provides info about what type is this task?)