### PR TITLE
WIP: fix: #421 dataview task mouseGripDown

### DIFF
--- a/src/ui/hooks/use-edit/create-edit-handlers.ts
+++ b/src/ui/hooks/use-edit/create-edit-handlers.ts
@@ -4,7 +4,7 @@ import { get, Readable, Writable } from "svelte/store";
 
 import { ObsidianFacade } from "../../../service/obsidian-facade";
 import { PlacedTask, UnscheduledTask } from "../../../types";
-import { createTask } from "../../../util/task-utils";
+import { createTask, getSchedueldDayFromText } from "../../../util/task-utils";
 
 import { EditMode, EditOperation } from "./types";
 
@@ -55,11 +55,16 @@ export function createEditHandlers({
     const withAddedTime = {
       ...task,
       startMinutes: get(cursorMinutes),
-      // todo: add a proper fix
-      startTime: task.location
-        ? getDateFromPath(task.location.path, "day") || window.moment()
-        : window.moment(),
+      startTime:
+        getSchedueldDayFromText(task) ||
+        getDateFromPath(task.location.path, "day"),
     };
+
+    if (!withAddedTime.startTime) {
+      throw new Error(
+        "Could not get the day of the task. It should be provided through the Tasks Plugins schduled feature, or the path of the daily note. If you did provide the day through one of these options, please report the issue at https://github.com/ivan-lednev/obsidian-day-planner/issues",
+      );
+    }
 
     startEdit({ task: withAddedTime, mode: EditMode.DRAG, day });
   }

--- a/src/util/task-utils.ts
+++ b/src/util/task-utils.ts
@@ -9,7 +9,7 @@ import {
   scheduledPropRegExp,
   shortScheduledPropRegExp,
 } from "../regexp";
-import type { Task } from "../types";
+import type { Task, UnscheduledTask } from "../types";
 import { PlacedTask } from "../types";
 
 import { getId } from "./id";
@@ -130,4 +130,19 @@ export function createTask(day: Moment, startMinutes: number): PlacedTask {
       xOffsetPercent: 0,
     },
   };
+}
+
+export function getSchedueldDayFromText(task: UnscheduledTask) {
+  const matches =
+    scheduledPropRegExp.exec(task.text) ||
+    keylessScheduledPropRegExp.exec(task.text) ||
+    shortScheduledPropRegExp.exec(task.text);
+
+  if (!matches) {
+    return undefined;
+  }
+  const [fullMatch, preFix] = matches;
+  const scheduledDay = fullMatch.replace(preFix, "");
+
+  return window.moment(scheduledDay);
 }


### PR DESCRIPTION
# Fix grap of dataview inserted tasks
Closes #421
I tested it with the task plugin. It works with tasks scheduled by the task plugin and tasks in the daily note. I did not figure out, if it is supposed to work for mobile as well.

## Manual tests I did:
### Steps before testing
-  install dataview plugin
- instll tasks plugin
- run obsidian-day-planner
### Tests
- [x] put a task in the daily note and go to the timeline, where you grap it from the  unscheduled tasks and put it on a timeslot (worked before, but since this I worked on affecting code I made sure it still works)
- [x]  go to any note and add a task. Schedule it for a certain day and put the hashtag "#tasks" in the file. Go to the timeline and edit the dataview filter to include the "#tasks" hashtag. now go to the previously chosen day and grap the task from the unscheduled tasks. it should work the same, like the task in the daily notes now. 

## Comments
I am not quite happy with the naming, but I did the best I could, without a refactor. Since the Tasks plugin uses the naming scheduled for days and this plugin uses the naming scheduled for timeslots. 
Also I did not really get the naming starttime, which seems to be a date and not a time. I hope I did not get this wrong and break anything else. 
