### PR TITLE
feat: option for whether new events created are bullet or check

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -44,6 +44,7 @@ export interface DayPlannerSettings {
   icals: Array<IcalConfig>;
   colorOverrides: Array<ColorOverride>;
   releaseNotes: boolean;
+  eventFormat: "task" | "bullet";
 }
 
 export const defaultSettings: DayPlannerSettings = {
@@ -77,6 +78,7 @@ export const defaultSettings: DayPlannerSettings = {
   icals: [],
   colorOverrides: [],
   releaseNotes: true,
+  eventFormat: "task",
 };
 
 export const defaultSettingsForTests = {

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -124,6 +124,23 @@ export class DayPlannerSettingsTab extends PluginSettingTab {
           });
       });
 
+    new Setting(containerEl)
+      .setName("Event Format")
+      .setDesc("Event format when new event added via calendar interaction.")
+      .addDropdown((component) =>
+        component
+          .addOptions({
+            bullet: 'Bullet "- "',
+            task: 'Task "- [ ] "',
+          })
+          .setValue(this.plugin.settings().eventFormat)
+          .onChange((value) => {
+            this.update({
+              eventFormat: value as DayPlannerSettings["eventFormat"],
+            });
+          }),
+      );
+
     containerEl.createEl("h2", { text: "Remote calendars" });
 
     this.plugin.settings().icals.map((ical, index) =>

--- a/src/util/task-utils.ts
+++ b/src/util/task-utils.ts
@@ -117,6 +117,8 @@ export function offsetYToMinutes(
 }
 
 export function createTask(day: Moment, startMinutes: number): PlacedTask {
+  const eventFormat = get(settings).eventFormat;
+
   return {
     id: getId(),
     startMinutes,
@@ -124,7 +126,7 @@ export function createTask(day: Moment, startMinutes: number): PlacedTask {
     firstLineText: "New item",
     text: "New item",
     startTime: minutesToMomentOfDay(startMinutes, day),
-    listTokens: "- [ ] ",
+    listTokens: eventFormat === "bullet" ? "- " : "- [ ] ",
     placing: {
       widthPercent: 100,
       xOffsetPercent: 0,


### PR DESCRIPTION
Used when creating new event from calendar view.

I took my best guess as to where this might fit into the options page.
Feel free to suggest alternatives or to adjust as you see fit.

This satisfies the request in #497.