### PR TITLE
fix: avoid detach timeline pane on init if it already exists

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -74,6 +74,12 @@ export default class DayPlanner extends Plugin {
 
   initTimelineLeafSilently = async () => {
     this.app.workspace.onLayoutReady(async () => {
+      const [firstExistingTimeline] =
+        this.app.workspace.getLeavesOfType(viewTypeTimeline);
+      if (firstExistingTimeline) {
+        return;
+      }
+
       await this.detachLeavesOfType(viewTypeTimeline);
 
       await this.app.workspace.getRightLeaf(false)?.setViewState({


### PR DESCRIPTION
By always doing `detach` -> `setViewState` in `initTimelineLeafSilently`, the layout was lost when the pane already existed and was laid out.
Related issue: https://github.com/ivan-lednev/obsidian-day-planner/issues/543

I don't think it will affect the operation since it uses [the `initTimelineLeaf` logic](https://github.com/k4a-l/obsidian-day-planner/blob/fix-avoid-detach-timeline-pane-on-init/src/main.ts#L92-L98), but if you have another reason for not including this logic in `initTimelineLeafSilently`, please let me know.


## diff
### before

https://github.com/user-attachments/assets/415fcb25-63da-43bb-9d67-38f1d7928bb4



- The layout of the timeline placed in the lower right corner is lost.

### after

https://github.com/user-attachments/assets/3356fbb4-a703-4be3-90db-bbc6c8ae1f30



- The layout is preserved.

