### PR TITLE
Add more icons

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,6 +29,8 @@ export const icons = [
   "broken-link",
   "bullet-list",
   "calendar-with-checkmark",
+  "calendar-clock",
+  "calendar-range",
   "checkmark",
   "create-new",
   "cross",


### PR DESCRIPTION
Add some more calendar icons that exist in Lucide. IMO `calendar-clock` is better representative of the purpose of Day Planner, and avoids clashing with other plugins that use `calendar-with-checkmark` like the venerable Calendar plugin.

It is possible to manually edit the json file to be whatever icon you like, but having it as an option in the list is much easier to use.