### PR TITLE
fix: Move block and push neighbouring blocks mal-function

### DIFF
--- a/src/ui/hooks/use-edit/transform/resize-and-shift-others.ts
+++ b/src/ui/hooks/use-edit/transform/resize-and-shift-others.ts
@@ -36,9 +36,9 @@ export function resizeAndShiftOthers(
     (result, current) => {
       const previous = last(result) || updated;
 
-      if (
-        getEndMinutes(previous) > getMinutesSinceMidnight(current.startTime)
-      ) {
+      const isSameDay = current.location!.path === updated.location!.path;
+      const currentOverlapsPrevious = getEndMinutes(previous) > getMinutesSinceMidnight(current.startTime);
+      if (currentOverlapsPrevious && isSameDay) {
         return [
           ...result,
           {
@@ -89,10 +89,9 @@ export function resizeFromTopAndShiftOthers(
     .reduce<WithTime<LocalTask>[]>((result, current) => {
       const nextInTimeline = last(result) || updated;
 
-      if (
-        getMinutesSinceMidnight(nextInTimeline.startTime) <
-        getEndMinutes(current)
-      ) {
+      const nextOverlapsPrevious = getMinutesSinceMidnight(nextInTimeline.startTime) < getEndMinutes(current);
+      const isSameDay = current.location!.path === updated.location!.path;
+      if (nextOverlapsPrevious && isSameDay) {
         return [
           ...result,
           {

--- a/src/ui/hooks/use-edit/transform/resize-and-shift-others.ts
+++ b/src/ui/hooks/use-edit/transform/resize-and-shift-others.ts
@@ -89,9 +89,9 @@ export function resizeFromTopAndShiftOthers(
     .reduce<WithTime<LocalTask>[]>((result, current) => {
       const nextInTimeline = last(result) || updated;
 
-      const nextOverlapsPrevious = getMinutesSinceMidnight(nextInTimeline.startTime) < getEndMinutes(current);
+      const nextOverlapsCurrent = getMinutesSinceMidnight(nextInTimeline.startTime) < getEndMinutes(current);
       const isSameDay = current.location!.path === updated.location!.path;
-      if (nextOverlapsPrevious && isSameDay) {
+      if (nextOverlapsCurrent && isSameDay) {
         return [
           ...result,
           {

--- a/src/ui/hooks/use-edit/transform/resize-and-shrink-others.ts
+++ b/src/ui/hooks/use-edit/transform/resize-and-shrink-others.ts
@@ -37,8 +37,9 @@ export function resizeAndShrinkOthers(
       const previous = last(result) || updated;
       const currentNeedsToShrink =
         getEndMinutes(previous) > getMinutesSinceMidnight(current.startTime);
-
-      if (currentNeedsToShrink) {
+      const isSameDay = current.location!.path === updated.location!.path;
+    
+      if (currentNeedsToShrink && isSameDay) {
         const newCurrentStartMinutes = getEndMinutes(previous);
         const newCurrentDurationMinutes =
           getEndMinutes(current) - newCurrentStartMinutes;
@@ -99,8 +100,9 @@ export function resizeFromTopAndShrinkOthers(
       const currentNeedsToShrink =
         getMinutesSinceMidnight(nextInTimeline.startTime) <
         getEndMinutes(current);
+      const isSameDay = current.location!.path === updated.location!.path;
 
-      if (currentNeedsToShrink) {
+      if (currentNeedsToShrink && isSameDay) {
         const currentNeedsToMove =
           getMinutesSinceMidnight(nextInTimeline.startTime) -
             getMinutesSinceMidnight(current.startTime) <


### PR DESCRIPTION
Fixes bug in multi day view where using the push or shrink buttons would move tasks in following days in unexpected ways.
The fix makes the functions only affect tasks from the same day as the edited, i.e. tasks that are in the same daily note. It may be worth making this configurable or finding a cleaner solution.
Fixes: https://github.com/ivan-lednev/obsidian-day-planner/issues/682