### PR TITLE
fix: toggle task deco/timestamp in timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+## changes
+
+- conditionally removes timestamps in render-task-markdown based on the task decoration toggle (showTimestampInTaskBlock)
+- to do this, also edited removeTimestampFromStart function and looseTimestampAtStartOfLineRegExp const
+	- looseTimestampAtStartOfLineRegExp edited to get timestamp even if there are task/list markers in front of them
+	- removeTimestampFromStart brought into the render thing based on showTimestampInTaskBlock 
+
+# original README
+
 - 🗳️ [Add '👍' reactions under the issues important to you.](https://github.com/ivan-lednev/obsidian-day-planner/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc) This helps me prioritize my work
 - 🪲 [Report bugs and suggest features](https://github.com/ivan-lednev/obsidian-day-planner/issues)
 - ❓ [Ask questions](https://github.com/ivan-lednev/obsidian-day-planner/discussions/new?category=q-a)

--- a/src/regexp.ts
+++ b/src/regexp.ts
@@ -26,9 +26,10 @@ export const headingRegExp = /^(#+)\s/;
 export const obsidianBlockIdRegExp = /\s\^[a-z1-9-]+$/i;
 
 export const looseTimestampAtStartOfLineRegExp = new RegExp(
-  `^(?<start>${time})(?:${durationSeparator}(?<end>${time}))?`,
+  `^(?<taskmarker>\\s*[-+*]\\s*\\[[ x]\\]\\s*)?(?<start>${time})(?:${durationSeparator}(?<end>${time}))?`,
   "im",
 );
+
 export const strictTimestampAnywhereInLineRegExp = new RegExp(
   `(?<start>${strictTime})(?:${durationSeparator}(?<end>${strictTime}))?`,
   "im",

--- a/src/ui/actions/render-task-markdown.ts
+++ b/src/ui/actions/render-task-markdown.ts
@@ -6,7 +6,11 @@ import type { DayPlannerSettings } from "../../settings";
 import type { LocalTask } from "../../task-types";
 import type { RenderMarkdown } from "../../types";
 import { deleteProps } from "../../util/properties";
-import { getFirstLine, getRenderKey } from "../../util/task-utils";
+import {
+  getFirstLine,
+  getRenderKey,
+  removeTimestampFromStart,
+} from "../../util/task-utils";
 import { normalizeNewlines } from "../../util/util";
 
 import { createMemo } from "./memoize-props";
@@ -45,11 +49,16 @@ export function renderTaskMarkdown(
     const displayedText = normalizeNewlines(
       deleteProps(getDisplayedText(task)),
     );
-    const onlyFirstLineIfNeeded = settings.showSubtasksInTaskBlocks
+
+    let finalText = settings.showSubtasksInTaskBlocks
       ? displayedText
       : getFirstLine(displayedText);
 
-    onDestroy.push(renderMarkdown(el, onlyFirstLineIfNeeded));
+    if (!settings.showTimestampInTaskBlock) {
+      finalText = removeTimestampFromStart(finalText);
+    }
+
+    onDestroy.push(renderMarkdown(el, finalText));
 
     if (!task.lines) {
       return;

--- a/src/util/task-utils.ts
+++ b/src/util/task-utils.ts
@@ -258,7 +258,10 @@ export function removeListTokens(text: string) {
 }
 
 export function removeTimestampFromStart(text: string) {
-  return text.replace(looseTimestampAtStartOfLineRegExp, "");
+  return text.replace(
+    looseTimestampAtStartOfLineRegExp,
+    (_, taskmarker) => taskmarker ?? "",
+  );
 }
 
 export function isTimeEqual(a: LocalTask, b: LocalTask) {


### PR DESCRIPTION
fix #536: "Show a timestamp next to task in timeline" toggle in settings under "Task decoration" shows or hides timestamps in timeline.