### PR TITLE
fix: add task to existing daily note

### DIFF
--- a/src/service/dataview-facade.ts
+++ b/src/service/dataview-facade.ts
@@ -1,12 +1,12 @@
 import { partition } from "lodash/fp";
 import type { Vault } from "obsidian";
 import { STask, type DataviewApi } from "obsidian-dataview";
+import { isNotVoid } from "typed-assert";
 
 import {
   type Scheduler,
   createBackgroundBatchScheduler,
 } from "../util/scheduler";
-import { isNotVoid } from "typed-assert";
 
 interface STaskCacheEntry {
   mtime: number;

--- a/src/service/diff-writer.ts
+++ b/src/service/diff-writer.ts
@@ -1,6 +1,10 @@
 import { groupBy } from "lodash/fp";
 import type { Root } from "mdast";
-import { getDateFromPath } from "obsidian-daily-notes-interface";
+import {
+  getAllDailyNotes,
+  getDailyNote,
+  getDateFromPath,
+} from "obsidian-daily-notes-interface";
 import { isNotVoid } from "typed-assert";
 
 import {
@@ -260,9 +264,14 @@ function mapTaskDiffToUpdate(props: {
       };
     }
 
+    const dailyNoteIfPresent = getDailyNote(task.startTime, getAllDailyNotes());
+    const mdastPath = dailyNoteIfPresent
+      ? dailyNoteIfPresent.path
+      : createDailyNotePath(task.startTime);
+
     return {
       type: "mdast",
-      path: createDailyNotePath(task.startTime),
+      path: mdastPath,
       updateFn: (root: Root) => {
         const taskRoot = fromMarkdown(taskTextWithUpdatedProps);
         const listItemToInsert = findFirst(taskRoot, checkListItem);

--- a/tests/diff-writer.test.ts
+++ b/tests/diff-writer.test.ts
@@ -34,6 +34,8 @@ vi.mock("obsidian-daily-notes-interface", () => ({
     format: "YYYY-MM-DD",
     folder: ".",
   })),
+  getAllDailyNotes: vi.fn(() => []),
+  getDailyNote: vi.fn(() => null),
   DEFAULT_DAILY_NOTE_FORMAT: "YYYY-MM-DD",
 }));
 

--- a/tests/store/redux.test.ts
+++ b/tests/store/redux.test.ts
@@ -1,5 +1,6 @@
 import { readFile } from "fs/promises";
 
+import type { Vault } from "obsidian";
 import type { STask } from "obsidian-dataview";
 import { describe, expect, test } from "vitest";
 
@@ -10,7 +11,6 @@ import {
 import { makeStore } from "../../src/redux/store";
 import { DataviewFacade } from "../../src/service/dataview-facade";
 import { createSTask } from "../../src/util/dataview";
-import type { Vault } from "obsidian";
 
 export async function getIcalFixture(file: string) {
   return readFile(`fixtures/${file}.txt`, {

--- a/vite-setup.ts
+++ b/vite-setup.ts
@@ -17,6 +17,8 @@ vi.mock("obsidian-dataview", () => ({
 vi.mock("obsidian-daily-notes-interface", () => ({
   default: vi.fn(),
   getDateFromPath: vi.fn(() => null),
+  getDailyNote: vi.fn(() => null),
+  getAllDailyNotes: vi.fn(() => []),
   DEFAULT_DAILY_NOTE_FORMAT: defaultDayFormat,
 }));
 


### PR DESCRIPTION
Daily notes may be moved to a different folder,
manually by an user or
automatically by a tool to structure them.

---

Relevant change is in `src/service/diff-writer.ts`, remaining files is the linter/formatter + test mocks.