### PR TITLE
Remove raw iCal caching and onIcalsFetched callback; simplify iCal listener flow

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -44,11 +44,7 @@ import {
   type PathToListProps,
 } from "./redux/dataview/dataview-slice";
 import { editCanceled, visibleDaysUpdated } from "./redux/global-slice";
-import {
-  icalRefreshRequested,
-  type IcalState,
-  initialIcalState,
-} from "./redux/ical/ical-slice";
+import { icalRefreshRequested } from "./redux/ical/ical-slice";
 import { settingsUpdated } from "./redux/settings-slice";
 import { type AppDispatch, createReactor } from "./redux/store";
 import { createUseSelector } from "./redux/use-selector";
@@ -59,11 +55,7 @@ import { PeriodicNotes } from "./service/periodic-notes";
 import { STaskEditor } from "./service/stask-editor";
 import { VaultFacade } from "./service/vault-facade";
 import { WorkspaceFacade } from "./service/workspace-facade";
-import {
-  type DayPlannerSettings,
-  defaultSettings,
-  type PluginData,
-} from "./settings";
+import { type DayPlannerSettings, defaultSettings } from "./settings";
 import type { RemoteTask } from "./task-types";
 import { createGetTasksApi } from "./tasks-plugin";
 import type { ObsidianContext, OnUpdateFn, PointerDateTime } from "./types";
@@ -96,7 +88,7 @@ export default class DayPlanner extends Plugin {
   private transactionWriter!: TransactionWriter;
 
   async onload() {
-    const initialPluginData: PluginData = {
+    const initialSettings: DayPlannerSettings = {
       ...defaultSettings,
       ...(await this.loadData()),
     };
@@ -120,11 +112,6 @@ export default class DayPlanner extends Plugin {
       this.app.vault,
     );
 
-    const icalStateWithCachedRawIcals: IcalState = {
-      ...initialIcalState,
-      plainTextIcals: initialPluginData.rawIcals || [],
-    };
-
     const {
       getState,
       dispatch,
@@ -137,14 +124,8 @@ export default class DayPlanner extends Plugin {
       pointerDateTime,
       dataviewRefreshSignal,
     } = createReactor({
-      preloadedState: {
-        ical: icalStateWithCachedRawIcals,
-      },
       dataviewFacade: this.dataviewFacade,
       listPropsParser,
-      onIcalsFetched: async (rawIcals) => {
-        await this.saveData({ ...this.settings(), rawIcals });
-      },
     });
 
     this.sTaskEditor = new STaskEditor(
@@ -158,7 +139,7 @@ export default class DayPlanner extends Plugin {
       listenerMiddleware.clearListeners();
     });
 
-    this.initSettingsStore({ initialSettings: initialPluginData, dispatch });
+    this.initSettingsStore({ initialSettings, dispatch });
     this.registerViews({
       dispatch,
       remoteTasks,

--- a/src/redux/listener-middleware.ts
+++ b/src/redux/listener-middleware.ts
@@ -6,7 +6,7 @@ import { createBackgroundBatchScheduler } from "../util/scheduler";
 
 import { dataviewChange } from "./dataview/dataview-slice";
 import { createListPropsParseListener } from "./dataview/init-dataview-listeners";
-import { icalRefreshRequested, icalsFetched } from "./ical/ical-slice";
+import { icalRefreshRequested } from "./ical/ical-slice";
 import {
   checkIcalEventsChanged,
   checkVisibleDaysChanged,
@@ -48,13 +48,6 @@ export function initListenerMiddleware(props: { extra: ReduxExtraArgument }) {
     effect: createIcalParseListener({
       scheduler: icalParseScheduler,
     }),
-  });
-
-  listenerMiddleware.startListening({
-    actionCreator: icalsFetched,
-    effect: async (action, listenerApi) => {
-      await listenerApi.extra.onIcalsFetched(action.payload);
-    },
   });
 
   listenerMiddleware.startListening({

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -22,7 +22,7 @@ import {
   selectListProps,
 } from "./dataview/dataview-slice";
 import { editCanceled, globalSlice } from "./global-slice";
-import { icalSlice, type RawIcal, selectRemoteTasks } from "./ical/ical-slice";
+import { icalSlice, selectRemoteTasks } from "./ical/ical-slice";
 import { initListenerMiddleware } from "./listener-middleware";
 import { searchSlice } from "./search-slice";
 import { selectDataviewSource, settingsSlice } from "./settings-slice";
@@ -57,19 +57,16 @@ export const makeStore = (
 };
 
 export function createReactor(props: {
-  preloadedState: Partial<RootState>;
+  preloadedState?: Partial<RootState>;
   dataviewFacade: DataviewFacade;
   listPropsParser: ListPropsParser;
-  onIcalsFetched: (rawIcals: RawIcal[]) => Promise<void>;
 }) {
-  const { preloadedState, dataviewFacade, listPropsParser, onIcalsFetched } =
-    props;
+  const { preloadedState = {}, dataviewFacade, listPropsParser } = props;
 
   const listenerMiddleware = initListenerMiddleware({
     extra: {
       dataviewFacade,
       listPropsParser,
-      onIcalsFetched,
     },
   });
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,7 +1,6 @@
 import type { HexString } from "obsidian";
 
 import { defaultDayFormat } from "./constants";
-import type { RawIcal } from "./redux/ical/ical-slice";
 
 export interface IcalConfig {
   name: string;
@@ -68,12 +67,6 @@ export interface DayPlannerSettings {
   multiDayRange: "full-week" | "work-week" | "3-days";
   timelineColumns: TimelineColumns;
 }
-
-export interface Cache {
-  rawIcals: Array<RawIcal>;
-}
-
-export type PluginData = DayPlannerSettings & Cache;
 
 export const defaultSettings: DayPlannerSettings = {
   snapStepMinutes: 10,

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,6 @@ import type Fraction from "fraction.js";
 import type { Moment } from "moment";
 import type { Readable, Writable } from "svelte/store";
 
-import type { RawIcal } from "./redux/ical/ical-slice";
 import { type AppDispatch } from "./redux/store";
 import type { UseSelector } from "./redux/use-selector";
 import type { DataviewFacade } from "./service/dataview-facade";
@@ -91,5 +90,4 @@ export type DateRange = Writable<Moment[]> & { untrack: () => void };
 export type ReduxExtraArgument = {
   dataviewFacade: DataviewFacade;
   listPropsParser: ListPropsParser;
-  onIcalsFetched: (rawIcals: RawIcal[]) => Promise<void>;
 };

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -182,8 +182,6 @@ async function setUp(props: {
 
   const onEditCanceled = vi.fn();
   const onEditConfirmed = vi.fn();
-  const onIcalsFetched = vi.fn();
-
   const defaultPreloadedStateForTests: Partial<RootState> = {
     obsidian: {
       ...initialState,
@@ -207,7 +205,6 @@ async function setUp(props: {
       },
     },
     dataviewFacade,
-    onIcalsFetched,
     listPropsParser,
   });
 

--- a/tests/store/ical.test.ts
+++ b/tests/store/ical.test.ts
@@ -75,7 +75,6 @@ function makeStoreForTests(props?: { preloadedState?: Partial<RootState> }) {
         new InMemoryVault([]) as unknown as Vault,
         new FakeMetadataCache({}) as unknown as MetadataCache,
       ),
-      onIcalsFetched: async () => {},
     },
   });
 


### PR DESCRIPTION
### Motivation

- Eliminate storing and propagating raw iCal payloads through plugin settings and Redux to simplify iCal handling and reduce persisted state surface.
- Remove the async `onIcalsFetched` callback and related preloaded iCal state since raw iCal caching is no longer required.
- Clean up associated types and listeners to match the simplified iCal flow.

### Description

- Removed `RawIcal`/raw iCal caching from `settings`, `types`, and Redux-related code and deleted the `Cache`/`PluginData` shape from `settings.ts`.
- Eliminated `onIcalsFetched` argument from `createReactor` and `ReduxExtraArgument`, made `preloadedState` optional in `createReactor`, and defaulted it to `{}` in `store.ts`.
- Removed the `icalsFetched` listener and related handling in `listener-middleware.ts` and no longer preload iCal state in `main.ts`, including deleting code that saved raw iCals to plugin data.
- Adjusted imports and type references throughout the codebase to drop `RawIcal` usages and updated variable names (`initialPluginData` -> `initialSettings`).
- Updated tests to reflect the new flow by removing `onIcalsFetched` fixtures and expectations in `tests/integration.test.ts` and `tests/store/ical.test.ts`.

### Testing

- Ran the automated test suite (`npm test`), which includes unit and integration tests, and all tests completed successfully after the changes. 
- Updated and executed `tests/integration.test.ts` and `tests/store/ical.test.ts`, and both updated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a06aa79834832bb0bfc67c4d5d11ad)