### PR TITLE
Trigger iCal fetch once at plugin startup

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -483,6 +483,8 @@ export default class DayPlanner extends Plugin {
       }, icalRefreshIntervalMillis),
     );
 
+    dispatch(icalRefreshRequested());
+
     this.registerEvent(
       this.app.metadataCache.on(
         // @ts-expect-error


### PR DESCRIPTION
### Motivation
- Ensure iCal data is fetched immediately when the plugin initializes so remote calendar events are available on first load in addition to the existing periodic refresh.

### Description
- Call `dispatch(icalRefreshRequested())` once during plugin initialization by adding the dispatch immediately after the existing interval registration in `src/main.ts`.

### Testing
- Ran `npm run typescript` which completed successfully.
- Ran `npm run test -- tests/store/ical.test.ts` which exercised the iCal listeners but failed with two assertion failures and an unhandled `ReferenceError: window is not defined` (failures appear to be present in the repository test environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1af239e40832b8b3d1a33723dc259)