### PR TITLE
Update needle.svelte to use Svelte 4 reactive primitives and explicit props

### DIFF
--- a/src/ui/components/needle.svelte
+++ b/src/ui/components/needle.svelte
@@ -1,16 +1,25 @@
 <script lang="ts">
-  import { currentTime } from "../../global-store/current-time";
+  import { currentTimeSignal } from "../../global-store/current-time";
   import { timeToTimelineOffset } from "../../global-store/derived-settings";
   import { settings } from "../../global-store/settings";
   import { getMinutesSinceMidnight } from "../../util/moment";
 
-  export let autoScrollBlocked = false;
-  export let showBall: boolean | undefined = true;
+  type Props = {
+    autoScrollBlocked?: boolean;
+    showBall?: boolean;
+  };
+
+  const {
+    autoScrollBlocked = false,
+    showBall = true,
+  }: Required<Props> = $props();
 
   let el: HTMLDivElement;
-  let coords = timeToTimelineOffset(
-    getMinutesSinceMidnight($currentTime),
-    $settings,
+  const coords = $derived(
+    timeToTimelineOffset(
+      getMinutesSinceMidnight(currentTimeSignal.current),
+      $settings,
+    ),
   );
 
   function scrollIntoView() {
@@ -19,13 +28,10 @@
     }
   }
 
-  $: {
-    coords = timeToTimelineOffset(
-      getMinutesSinceMidnight($currentTime),
-      $settings,
-    );
+  $effect(() => {
+    coords;
     scrollIntoView();
-  }
+  });
 </script>
 
 <div


### PR DESCRIPTION
### Motivation

- Modernize the needle component to use the new Svelte reactive primitives and signal-based time source for more predictable reactivity.
- Provide explicit typed props with defaults to simplify prop handling and avoid implicit `let` semantics.

### Description

- Replace the `currentTime` store with `currentTimeSignal` and compute timeline offset with `getMinutesSinceMidnight(currentTimeSignal.current)` passed to `timeToTimelineOffset`.
- Replace the mutable `let coords` reactive assignment with a `$derived(...)` constant and use a `$effect(...)` to trigger `scrollIntoView()` when `coords` changes.
- Replace ad-hoc prop declarations with a typed `Props` type and destructure defaults from `$props()` for `autoScrollBlocked` and `showBall`.
- Keep DOM bindings unchanged while updating style/top bindings to use the new `coords` derived value.

### Testing

- Ran project type-check and `tsc` checks and they completed successfully.
- Ran the test suite (`npm test`) and all tests passed.
- Performed a local build (`npm run build`) which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c27fc4bc34832babf24d3ea63024df)