### PR TITLE
feat: replace drag/resize handles with direct block interaction

### DIFF
--- a/src/ui/actions/block-drag-resize.ts
+++ b/src/ui/actions/block-drag-resize.ts
@@ -1,0 +1,138 @@
+import TinyGesture from "tinygesture";
+
+import type { LocalTask, WithTime } from "../../task-types";
+import { EditMode } from "../hooks/use-edit/types";
+
+const edgeThresholdPx = 6;
+
+type EditStartFn = (task: WithTime<LocalTask>, mode: EditMode) => void;
+
+interface BlockDragResizeOptions {
+  getTask: () => LocalTask;
+  handleGripMouseDown: EditStartFn;
+  handleResizerMouseDown: EditStartFn;
+}
+
+type EdgeZone = "top" | "bottom" | "center";
+
+function getEdgeZone(
+  el: HTMLElement,
+  clientY: number,
+): EdgeZone {
+  const rect = el.getBoundingClientRect();
+  const relativeY = clientY - rect.top;
+  const blockHeight = rect.height;
+
+  if (relativeY <= edgeThresholdPx) {
+    return "top";
+  }
+
+  if (relativeY >= blockHeight - edgeThresholdPx) {
+    return "bottom";
+  }
+
+  return "center";
+}
+
+function getCursorForZone(zone: EdgeZone, isAllDay: boolean): string {
+  if (isAllDay) {
+    return "grab";
+  }
+
+  return zone === "center" ? "grab" : "ns-resize";
+}
+
+function getEditMode(zone: EdgeZone, isAllDay: boolean): EditMode {
+  if (isAllDay || zone === "center") {
+    return EditMode.DRAG;
+  }
+
+  return zone === "top" ? EditMode.RESIZE_FROM_TOP : EditMode.RESIZE;
+}
+
+function isCheckbox(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  return (
+    target.dataset.line !== undefined ||
+    (target instanceof HTMLInputElement && target.type === "checkbox")
+  );
+}
+
+export function createBlockDragResize(options: BlockDragResizeOptions) {
+  return (el: HTMLElement) => {
+    const { getTask, handleGripMouseDown, handleResizerMouseDown } = options;
+
+    let pointerDownZone: EdgeZone = "center";
+    let editStarted = false;
+    let pointerDownOnCheckbox = false;
+
+    const gesture = new TinyGesture(el);
+
+    function handlePointerDown(event: PointerEvent) {
+      pointerDownOnCheckbox = isCheckbox(event.target);
+
+      if (pointerDownOnCheckbox) {
+        return;
+      }
+
+      pointerDownZone = getEdgeZone(el, event.clientY);
+      editStarted = false;
+    }
+
+    function handlePointerMoveForCursor(event: PointerEvent) {
+      if (!editStarted && !pointerDownOnCheckbox) {
+        const currentTask = getTask();
+        const isAllDay = Boolean(currentTask.isAllDayEvent);
+        const zone = getEdgeZone(el, event.clientY);
+        el.style.cursor = getCursorForZone(zone, isAllDay);
+      }
+    }
+
+    function handlePointerLeave() {
+      if (!editStarted) {
+        el.style.cursor = "";
+      }
+    }
+
+    gesture.on("panmove", () => {
+      if (editStarted || pointerDownOnCheckbox) {
+        return;
+      }
+
+      editStarted = true;
+      const currentTask = getTask();
+      const isAllDay = Boolean(currentTask.isAllDayEvent);
+      el.style.cursor = pointerDownZone === "center" ? "grabbing" : "ns-resize";
+
+      const mode = getEditMode(pointerDownZone, isAllDay);
+
+      if (mode === EditMode.DRAG) {
+        handleGripMouseDown(currentTask as WithTime<LocalTask>, mode);
+      } else {
+        handleResizerMouseDown(currentTask as WithTime<LocalTask>, mode);
+      }
+    });
+
+    gesture.on("panend", () => {
+      editStarted = false;
+      pointerDownOnCheckbox = false;
+      el.style.cursor = "";
+    });
+
+    el.addEventListener("pointerdown", handlePointerDown);
+    el.addEventListener("pointermove", handlePointerMoveForCursor);
+    el.addEventListener("pointerleave", handlePointerLeave);
+
+    return {
+      destroy() {
+        gesture.destroy();
+        el.removeEventListener("pointerdown", handlePointerDown);
+        el.removeEventListener("pointermove", handlePointerMoveForCursor);
+        el.removeEventListener("pointerleave", handlePointerLeave);
+      },
+    };
+  };
+}

--- a/src/ui/components/time-block-controls.svelte
+++ b/src/ui/components/time-block-controls.svelte
@@ -4,11 +4,9 @@
   import { getObsidianContext } from "../../context/obsidian-context";
   import { type LocalTask } from "../../task-types";
   import type { HTMLActionArray } from "../actions/use-actions";
+  import { createBlockDragResize } from "../actions/block-drag-resize";
   import { createTimeBlockMenu } from "../time-block-menu";
 
-  import DragControls from "./drag-controls.svelte";
-  import FloatingControls from "./floating-controls.svelte";
-  import ResizeControls from "./resize-controls.svelte";
   import Selectable from "./selectable.svelte";
 
   interface TimeBlockProps {
@@ -27,9 +25,18 @@
   } = $props();
 
   const {
-    editContext: { editOperation },
+    editContext: {
+      editOperation,
+      handlers: { handleGripMouseDown, handleResizerMouseDown },
+    },
     workspaceFacade,
   } = getObsidianContext();
+
+  const blockDragResize = createBlockDragResize({
+    getTask: () => task,
+    handleGripMouseDown,
+    handleResizerMouseDown,
+  });
 </script>
 
 <Selectable
@@ -38,35 +45,10 @@
   selectionBlocked={Boolean($editOperation)}
 >
   {#snippet children(selectable)}
-    <FloatingControls active={selectable.state === "primary"}>
-      {#snippet anchor(floatingControls)}
-        {@render timeBlock({
-          isActive: selectable.state !== "none",
-          onPointerUp: selectable.onpointerup,
-          use: [...selectable.use, ...floatingControls.actions],
-        })}
-      {/snippet}
-
-      {#snippet topEnd({ isActive, setIsActive })}
-        <DragControls
-          --expanding-controls-position="absolute"
-          {isActive}
-          {setIsActive}
-          {task}
-        />
-      {/snippet}
-
-      {#snippet bottom({ isActive, setIsActive })}
-        {#if !task.isAllDayEvent}
-          <ResizeControls {isActive} reverse {setIsActive} {task} />
-        {/if}
-      {/snippet}
-
-      {#snippet top({ isActive, setIsActive })}
-        {#if !task.isAllDayEvent}
-          <ResizeControls fromTop {isActive} reverse {setIsActive} {task} />
-        {/if}
-      {/snippet}
-    </FloatingControls>
+    {@render timeBlock({
+      isActive: selectable.state !== "none",
+      onPointerUp: selectable.onpointerup,
+      use: [...selectable.use, blockDragResize],
+    })}
   {/snippet}
 </Selectable>


### PR DESCRIPTION
# feat: replace drag/resize handles with direct block interaction

## Summary

Replace the floating drag handle (grip icon) and resize handles with direct interaction on the time block itself:

- **Drag from the center** of a block to move it
- **Drag from the top or bottom edge** (~6px zone) to resize
- Cursor changes on hover to indicate which action will happen (`grab` vs `ns-resize`)
- Checkbox clicks are excluded from drag detection so they keep working normally

This removes the `FloatingControls`, `DragControls`, and `ResizeControls` from the time block rendering chain entirely, resulting in a cleaner UI with no icon clutter.

## Changes

- **New**: `src/ui/actions/block-drag-resize.ts` - Svelte action using TinyGesture that detects pointer position on the block to determine move vs resize
- **Modified**: `src/ui/components/time-block-controls.svelte` - Removed floating controls, wires up the new direct drag/resize action

## Test plan

- [ ] Drag from center of a time block to move it
- [ ] Drag from top edge to resize from top
- [ ] Drag from bottom edge to resize from bottom
- [ ] Hover cursor shows `grab` in center, `ns-resize` at edges
- [ ] Click checkboxes inside blocks - should toggle without triggering drag
- [ ] All-day events only support drag (no resize)
- [ ] Right-click context menu still works
- [ ] Touch devices: long press for context menu, pan to drag/resize
