### PR TITLE
fix: prevent numbers followed by letters from being parsed as timestamps

### DIFF
--- a/src/regexp.ts
+++ b/src/regexp.ts
@@ -15,7 +15,7 @@ const amPm = "\\s?[apAP][mM](?!\\w)";
 
 const date = "\\d{4}-\\d{2}-\\d{2}";
 
-const time = `(${hours})(?:${hourMinuteSeparator}?(${minutes}))(${amPm})?`;
+const time = `(${hours})(?:${hourMinuteSeparator}?(${minutes}))(${amPm})?(?!\\w)`;
 const strictTime = `${hours}${strictHourMinuteSeparator}${minutes}(${amPm})?`;
 
 export const listTokenWithSpacesRegExp = new RegExp(listTokenWithSpaces);


### PR DESCRIPTION
## Summary

Bullet list items containing numbers followed by letters (e.g. "250g sugar", "15g salt") are no longer falsely parsed as timestamps and added to the timeline.

## Why this matters

The time regex was backtracking on inputs like "250g": `\d{1,2}` matched "2" and `\d{2}` matched "50", treating it as 2:50. The trailing "g" was ignored.

Adding `(?!\w)` after the time pattern ensures the matched timestamp is not part of a larger word.

## Changes

- `src/regexp.ts`: Added negative lookahead `(?!\w)` to the `time` pattern.

## Testing

Verified with Node.js regex tests:
- "250g sugar" - no match (was: matched as 2:50)
- "15g salt" - no match (was: matched as 1:5? depending on backtrack)
- "6 people" - no match
- "10:30 meeting" - match (valid timestamp)
- "6:00 dinner" - match (valid timestamp)
- "2:50pm meeting" - match (valid timestamp with am/pm)

Fixes #387

This contribution was developed with AI assistance (Claude Code).