### PR TITLE
feat: add semantic timeline column classes

### DIFF
--- a/src/ui/components/column.svelte
+++ b/src/ui/components/column.svelte
@@ -3,9 +3,11 @@
   import { settings } from "../../global-store/settings";
 
   export let visibleHours: number[];
+  let className: string | string[] = "";
+  export { className as class };
 </script>
 
-<div class="column">
+<div class={["column", className]}>
   <slot />
   {#each visibleHours as hour}
     <div style:height="{getHourSize($settings)}px" class="hour-block">

--- a/src/ui/components/timeline.svelte
+++ b/src/ui/components/timeline.svelte
@@ -99,7 +99,7 @@
 </script>
 
 {#if $settings.timelineColumns.planner}
-  <Column visibleHours={getVisibleHours($settings)}>
+  <Column class="planner-left-column" visibleHours={getVisibleHours($settings)}>
     {#if $isToday(day)}
       <Needle autoScrollBlocked={isUnderCursor} />
     {/if}
@@ -132,7 +132,7 @@
 {/if}
 
 {#if $settings.timelineColumns.timeTracker}
-  <Column visibleHours={getVisibleHours($settings)}>
+  <Column class="planner-right-column" visibleHours={getVisibleHours($settings)}>
     {#if $isToday(day)}
       <Needle autoScrollBlocked={isUnderCursor} showBall={false} />
     {/if}


### PR DESCRIPTION
## Summary
- Allow the reusable timeline `Column` component to receive class names.
- Add semantic `planner-left-column` and `planner-right-column` classes to the existing planner and time tracker timeline columns.

## Test plan
- ReadLints reports no diagnostics for changed files in Cursor.
- `npm run typescript` could not complete in this checkout because dependencies are not installed (`@tsconfig/svelte` and Svelte type definitions missing).


Made with [Cursor](https://cursor.com)